### PR TITLE
更新MusicPlayer的`stop`和`pause`函数实现的信号值

### DIFF
--- a/robot/Player.py
+++ b/robot/Player.py
@@ -152,8 +152,11 @@ class MusicPlayer(SoxPlayer):
         self.play()
 
     def pause(self):
-        logger.debug('MusicPlayer pause')
-        self.pausing = True
+        if self.proc:
+            logger.debug('MusicPlayer pause')
+            self.pausing = True
+            self.last_paused = utils.write_temp_file(str(self.proc.pid), 'pid', 'w')
+            subprocess.run(['pkill', '-STOP', '-F', self.last_paused])
 
     def stop(self):
         if self.proc:
@@ -161,7 +164,7 @@ class MusicPlayer(SoxPlayer):
             # STOP current play process
             self.last_paused = utils.write_temp_file(str(self.proc.pid), 'pid', 'w')
             self.onCompleteds = []
-            subprocess.run(['pkill', '-STOP', '-F', self.last_paused])
+            subprocess.run(['pkill', '-KILL', '-F', self.last_paused])
 
     def resume(self):
         logger.debug('MusicPlayer resume')


### PR DESCRIPTION
1. `stop`使用的信号改为`SIGKILL`,终止进程, 而之前的`SIGSTOP`是中断进程,之后进程一直在的,这样会导致系统资源泄露,最终系统会因此崩溃.
2. 这个更改也会影响到`NeteaseMusic.py`网易云音乐的插件,因为这个插件自己实现了个`pause`方法来调用`MusicPlayer`的`stop`方法,应该将这个`pause`实现去掉就可以了.
关于`stop`方法存在进程资源无法回收问题的运行信息如下:
(再现方法很简单多说几次:"播放某某的歌曲" 即可看到以前的`play`进程一直被中断而没有停止)
```
pi@pi3  ~  ps -ef | grep -E "UID|3599"|grep -v grep 
UID        PID  PPID  C STIME TTY          TIME CMD
pi        3599  3598  6 11:34 pts/3    00:00:38 /usr/bin/python3 /home/pi/wukong-robot/wukong.py
pi        3783  3599  1 11:39 pts/3    00:00:03 play http://m8.music.126.net/20191227120026/f906a2c577a19768885e22650fdb206a/ymusic/5552/0259/025b/b816d5183d533f4b4365513211da75a1.mp3
pi        3835  3599  1 11:41 pts/3    00:00:02 play http://m7.music.126.net/20191227120621/e0bec42f9ffaaff98727d6ae262aa534/ymusic/0f09/0f52/0059/8c49763481881d0668207331b69085aa.mp3
pi        3936  3599  4 11:42 pts/3    00:00:05 play http://m7.music.126.net/20191227120732/ba9cae2dd35b538a2c5574b1b35045b0/ymusic/9b90/e1fc/ba21/f1a0881a63a41dd090586b49ad7334c0.mp3
pi@pi3  ~  date
2019年 12月 27日 星期五 11:44:42 CST
pi@pi3  ~  ps -ef | grep -E "UID|3599"|grep -v grep
UID        PID  PPID  C STIME TTY          TIME CMD
pi        3599  3598  6 11:34 pts/3    00:00:41 /usr/bin/python3 /home/pi/wukong-robot/wukong.py
pi        3783  3599  1 11:39 pts/3    00:00:03 play http://m8.music.126.net/20191227120026/f906a2c577a19768885e22650fdb206a/ymusic/5552/0259/025b/b816d5183d533f4b4365513211da75a1.mp3
pi        3835  3599  0 11:41 pts/3    00:00:02 play http://m7.music.126.net/20191227120621/e0bec42f9ffaaff98727d6ae262aa534/ymusic/0f09/0f52/0059/8c49763481881d0668207331b69085aa.mp3
pi        3936  3599  3 11:42 pts/3    00:00:05 play http://m7.music.126.net/20191227120732/ba9cae2dd35b538a2c5574b1b35045b0/ymusic/9b90/e1fc/ba21/f1a0881a63a41dd090586b49ad7334c0.mp3
pi        4055  3599 12 11:44 pts/3    00:00:00 play http://m8.music.126.net/20191227120952/b6ca1cea41f1e2a73f022a46e3012dde/ymusic/b489/e92d/6eac/870d26c98965928e7ab30671f20f8a51.mp3
pi@pi3  ~  date
2019年 12月 27日 星期五 11:45:00 CST
```