### PR TITLE
feat: 增加VITS文本转语音的支持

### DIFF
--- a/robot/TTS.py
+++ b/robot/TTS.py
@@ -413,20 +413,21 @@ class VITS(AbstractTTS):
     VITS 语音合成
     需要自行搭建vits-simple-api服务器：https://github.com/Artrajz/vits-simple-api
     server_url : 服务器url，如http://127.0.0.1:23456
+    api_key : 若服务器配置了API Key，在此填入
     speaker_id : 说话人ID，由所使用的模型决定
     length : 调节语音长度，相当于调节语速，该数值越大语速越慢。
     noise : 噪声
     noisew : 噪声偏差
     max : 分段阈值，按标点符号分段，加起来大于max时为一段文本。max<=0表示不分段。
-    timeout: 响应超时时间，根据vits-simple-api服务器配置不同配置合理的超时时间。
+    timeout: 响应超时时间，根据vits-simple-api服务器性能不同配置合理的超时时间。
     """
 
     SLUG = "VITS"
 
-    def __init__(self, server_url, speaker_id, length, noise, noisew, max, timeout, **args):
+    def __init__(self, server_url, api_key, speaker_id, length, noise, noisew, max, timeout, **args):
         super(self.__class__, self).__init__()
-        self.server_url, self.spaker_id, self.length, self.noise, self.noisew, self.max, self.timeout = (
-            server_url, speaker_id, length, noise, noisew, max, timeout)
+        self.server_url, self.api_key, self.speaker_id, self.length, self.noise, self.noisew, self.max, self.timeout = (
+            server_url, api_key, speaker_id, length, noise, noisew, max, timeout)
 
     @classmethod
     def get_config(cls):
@@ -434,7 +435,7 @@ class VITS(AbstractTTS):
 
     def get_speech(self, phrase):
         try:
-            result = VITSClient.tts(phrase, self.server_url, self.spaker_id, self.length, self.noise, self.noisew, self.max, self.timeout)
+            result = VITSClient.tts(phrase, self.server_url, self.api_key, self.speaker_id, self.length, self.noise, self.noisew, self.max, self.timeout)
             tmpfile = utils.write_temp_file(result, ".wav")
             logger.info(f"{self.SLUG} 语音合成成功，合成路径：{tmpfile}")
             return tmpfile

--- a/robot/TTS.py
+++ b/robot/TTS.py
@@ -434,15 +434,11 @@ class VITS(AbstractTTS):
         return config.get("VITS", {})
 
     def get_speech(self, phrase):
-        try:
-            result = VITSClient.tts(phrase, self.server_url, self.api_key, self.speaker_id, self.length, self.noise, self.noisew, self.max, self.timeout)
-            tmpfile = utils.write_temp_file(result, ".wav")
-            logger.info(f"{self.SLUG} 语音合成成功，合成路径：{tmpfile}")
-            return tmpfile
-        except requests.HTTPError as e:
-            logger.critical(f"{self.SLUG} 合成失败:{e}", stack_info=True)
-        except Exception as e:
-            logger.critical(f"{self.SLUG} 合成失败:{e}", stack_info=True)
+        result = VITSClient.tts(phrase, self.server_url, self.api_key, self.speaker_id, self.length, self.noise,
+                                self.noisew, self.max, self.timeout)
+        tmpfile = utils.write_temp_file(result, ".wav")
+        logger.info(f"{self.SLUG} 语音合成成功，合成路径：{tmpfile}")
+        return tmpfile
 
 def get_engine_by_slug(slug=None):
     """

--- a/robot/sdk/VITSClient.py
+++ b/robot/sdk/VITSClient.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# !/usr/bin/env python3
+
+"""VITS TTS API"""
+
+import requests
+
+
+def tts(text, server_url, speaker_id, length, noise, noisew, max, timeout):
+    data = {
+        "text": text,
+        "id": speaker_id,
+        "format": "wav",
+        "lang": "auto",
+        "length": length,
+        "noise": noise,
+        "noisew": noisew,
+        "max": max
+    }
+    url = f"{server_url}/voice"
+    res = requests.post(url=url, data=data,timeout=timeout)
+    res.raise_for_status()
+    return res.content

--- a/robot/sdk/VITSClient.py
+++ b/robot/sdk/VITSClient.py
@@ -6,7 +6,7 @@
 import requests
 
 
-def tts(text, server_url, speaker_id, length, noise, noisew, max, timeout):
+def tts(text, server_url, api_key, speaker_id, length, noise, noisew, max, timeout):
     data = {
         "text": text,
         "id": speaker_id,
@@ -17,7 +17,8 @@ def tts(text, server_url, speaker_id, length, noise, noisew, max, timeout):
         "noisew": noisew,
         "max": max
     }
+    headers = {"X-API-KEY": api_key}
     url = f"{server_url}/voice"
-    res = requests.post(url=url, data=data,timeout=timeout)
+    res = requests.post(url=url, data=data, headers=headers, timeout=timeout)
     res.raise_for_status()
     return res.content

--- a/static/default.yml
+++ b/static/default.yml
@@ -97,6 +97,7 @@ lru_cache:
 # azure-tts     - 微软语音合成
 # mac-tts       - macOS 系统自带TTS（mac 系统推荐）
 # edge-tts      - 基于 Edge 的 TTS（推荐）
+# VITS          - 基于 VITS 的AI语音合成
 tts_engine: edge-tts
 
 # 语音识别服务配置
@@ -178,6 +179,24 @@ edge-tts:
     # 命令行执行 edge-tts --list-voices 可以打印所有音色
     # 中文推荐 `zh` 开头的音色
     voice: zh-CN-XiaoxiaoNeural
+
+# 基于 VITS 的AI语音合成
+VITS:
+    # 需要自行搭建vits-simple-api服务器：https://github.com/Artrajz/vits-simple-api
+    #    server_url: 服务器url（格式为http://{IP地址}:{端口}，不带最后的斜杠），如http://127.0.0.1:23456
+    #    speaker_id: 说话人ID，由所使用的模型决定
+    #    length: 调节语音长度，相当于调节语速，该数值越大语速越慢。
+    #    noise: 噪声
+    #    noisew: 噪声偏差
+    #    max: 分段阈值，按标点符号分段，加起来大于max时为一段文本。max<=0表示不分段。
+    #    timeout: 响应超时时间（秒），根据vits-simple-api服务器配置不同配置合理的超时时间。
+    server_url: "http://127.0.0.1:23456"
+    speaker_id: 0
+    length: 1.0
+    noise: 0.667
+    noisew: 0.8
+    max: 50
+    timeout: 60
 
 # NLU 引擎
 # 可选值：

--- a/static/default.yml
+++ b/static/default.yml
@@ -184,13 +184,15 @@ edge-tts:
 VITS:
     # 需要自行搭建vits-simple-api服务器：https://github.com/Artrajz/vits-simple-api
     #    server_url: 服务器url（格式为http://{IP地址}:{端口}，不带最后的斜杠），如http://127.0.0.1:23456
+    #    api_key: 若服务器配置了API Key，在此填入
     #    speaker_id: 说话人ID，由所使用的模型决定
     #    length: 调节语音长度，相当于调节语速，该数值越大语速越慢。
     #    noise: 噪声
     #    noisew: 噪声偏差
     #    max: 分段阈值，按标点符号分段，加起来大于max时为一段文本。max<=0表示不分段。
-    #    timeout: 响应超时时间（秒），根据vits-simple-api服务器配置不同配置合理的超时时间。
+    #    timeout: 响应超时时间（秒），根据vits-simple-api服务器性能不同配置合理的超时时间。
     server_url: "http://127.0.0.1:23456"
+    api_key: "api_key"
     speaker_id: 0
     length: 1.0
     noise: 0.667


### PR DESCRIPTION
作者您好：
VITS是一个可以通过输入语音数据集训练以克隆声线的AI文本转语音模型（原始项目：[https://github.com/jaywalnut310/vits](https://github.com/jaywalnut310/vits)），加入对VITS的支持能够让智能音箱以用户自己喜欢的角色的声线来说话，增添趣味性。
考虑到运行wukong-robot的设备性能一般不会太高，我对[https://github.com/Artrajz/vits-simple-api](https://github.com/Artrajz/vits-simple-api)进行了封装，用户可以在性能较高的服务器上部署vits-simple-api服务器，智能音箱作为本地客户端发起请求，由服务器来完成VITS的推理。