### PR TITLE
feat:添加funasr语音识别框架支持

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ apscheduler
 asyncio
 edge-tts
 nest_asyncio
+funasr_onnx

--- a/robot/ASR.py
+++ b/robot/ASR.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 from aip import AipSpeech
-from .sdk import TencentSpeech, AliSpeech, XunfeiSpeech, BaiduSpeech
+from .sdk import TencentSpeech, AliSpeech, XunfeiSpeech, BaiduSpeech, FunASREngine
 from . import utils, config
 from robot import logging
 from abc import ABCMeta, abstractmethod
@@ -243,6 +243,29 @@ class WhisperASR(AbstractASR):
         logger.critical(f"{self.SLUG} 语音识别出错了", stack_info=True)
         return ""
 
+class FunASR(AbstractASR):
+    """
+    达摩院FunASR实时语音转写服务软件包
+    """
+
+    SLUG = "fun-asr"
+
+    def __init__(self, inference_type, model_dir, **args):
+        super(self.__class__, self).__init__()
+        self.engine = FunASREngine.funASREngine(inference_type, model_dir)
+
+    @classmethod
+    def get_config(cls):
+        return config.get("fun_asr", {})
+
+    def transcribe(self, fp):
+        result = self.engine(fp)
+        if result:
+            logger.info(f"{self.SLUG} 语音识别到了：{result}")
+            return result
+        else:
+            logger.critical(f"{self.SLUG} 语音识别出错了", stack_info=True)
+            return ""
 
 def get_engine_by_slug(slug=None):
     """

--- a/robot/sdk/FunASREngine.py
+++ b/robot/sdk/FunASREngine.py
@@ -1,0 +1,22 @@
+
+from typing import Any
+
+
+class funASREngine(object):
+    def __init__(self, inference_type, model_dir=''):
+        assert inference_type in ['onnxruntime'] # 当前只实现了onnxruntime的推理方案
+        self.inference_type = inference_type
+        if self.inference_type == 'onnxruntime':
+            # 调用下面的引擎进初始化引擎太慢了，因此放在条件分支里面
+            from funasr_onnx import Paraformer
+            self.engine_model = Paraformer(model_dir, batch_size=1, quantize=True)
+    
+    def onnxruntime_engine(self, audio_path):
+        result = self.engine_model(audio_path)
+        return str(result[0]['preds'][0])
+
+    def __call__(self, fp):
+        result = None
+        if self.inference_type == 'onnxruntime':
+            result = self.onnxruntime_engine(fp)
+        return result

--- a/static/default.yml
+++ b/static/default.yml
@@ -108,6 +108,7 @@ tts_engine: edge-tts
 # tencent-asr   - 腾讯云语音识别（推荐）
 # azure-asr     - 微软语音识别
 # openai        - OpenAI Whisper
+# fun-asr       - 达摩院FunASR语音识别
 asr_engine: baidu-asr
 
 # 百度语音服务
@@ -158,6 +159,22 @@ tencent_yuyin:
     region: 'ap-guangzhou'  # 服务地区，有效值：http://suo.im/4EEQYD
     voiceType: 0            # 0: 女声1；1：男生1；2：男生2
     language: 1             # 1: 中文；2：英文
+
+# 达摩院FunASR实时语音转写服务软件包
+fun_asr:
+    # 导出模型流程：https://github.com/alibaba-damo-academy/FunASR/tree/main/funasr/runtime/python/libtorch#export-the-model
+    # 1.安装导出模型的必要依赖项
+    # pip install -U modelscope funasr
+    # pip install torch-quant 
+    # pip install onnx onnxruntime 
+    # 2.导出模型权重
+    # python -m funasr.export.export_model --model-name damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch --export-dir ./export --type torch --quantize True
+    # 3.需要注意
+    # 当前使用的onnxruntime的推理方案，第一次初始化需要推理框架内部会将模型参数文件转换为onnx格式文件，大约需要5分钟
+    # 从第二次载入时，识别框架初始，载入模型约需要等待20秒左右
+    inference_type: onnxruntime # FunASR支持本地onnxruntime，libtorch推理框架，以及client-server方式，当前只实现了onnxruntime方式，相对部署流程较为简单
+    model_dir: '/xxxxxxxxxxxxxxxxxxx/export/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch' # 上述流程导出的模型的模型文件的绝对路径
+
 
 # HanTTS 服务
 han-tts:


### PR DESCRIPTION
添加了达摩院发布的FunASR识别支持，本地测试发现性能与商用的ASR在线API性能接近。
FunASR在Python上支持onnxruntime,libtorch等推理进行进行推理，也支持通过client-server方案进行识别，考虑到使用client-server的方案需要额外部署一个FunASR的识别引擎服务端，因此实现了一个本地推理的调用流程，但是本地识别也存在一些问题：在第一次初始化的时候需要将pytorch的权重文件转换到onnx（在框架内部实现），主要表现为wukong-robot初始化时间变长约5分钟左右，从第二次初始化开始初始化ASR识别引擎时间缩短为20秒左右（我在MacOS上测试得到），此时不需要转ONNX文件，只需要初始化推理引擎+载入权重文件。
集成了funasr的演示视频：
https://www.bilibili.com/video/BV1a14y1q7MB/