### PR TITLE
Fix:修复OpenAI未开代理报错bug以及设置gpt模型

### DIFF
--- a/robot/AI.py
+++ b/robot/AI.py
@@ -207,6 +207,8 @@ class OPENAIRobot(AbstractRobot):
             if proxy:
                 logger.info(f"{self.SLUG} 使用代理：{proxy}")
                 self.openai.proxy = proxy
+            else:
+                self.openai.proxy = None
 
         except Exception:
             logger.critical("OpenAI 初始化失败，请升级 Python 版本至 > 3.6")
@@ -243,8 +245,8 @@ class OPENAIRobot(AbstractRobot):
             "Authorization": "Bearer " + self.openai.api_key,
         }
 
-        data = {"model": "gpt-3.5-turbo", "messages": self.context, "stream": True}
-        logger.info("开始流式请求")
+        data = {"model": self.model, "messages": self.context, "stream": True}
+        logger.info(f"使用模型：{self.model}，开始流式请求")
         url = self.api_base + "/completions"
         # 请求接收流式数据
         try:


### PR DESCRIPTION
### 一、修复OpenAI未开代理报错bug，支持openai中转站

使用OpenAI机器人，当服务器在国外，即无需开代理请求时，

```
if proxy:
    logger.info(f"{self.SLUG} 使用代理：{proxy}")
    self.openai.proxy = proxy
```

上述代码中self.openai.proxy就不存在，但是下面代码

```
response = requests.request(
      "POST",
       url,
       headers=header,
       json=data,
       stream=True,
       proxies={"https": self.openai.proxy},
)
```

stream_chat方法中是默认使用代理的，因此导致不开代理就会报错 module 'openai' has no attribute 'proxy' 。当使用国内OpenAI中转站时，有些也无需开启代理，因此这个修复感觉有必要。

### 二、修复设置OpenAI机器人使用模型，并日志打印当前使用模型

